### PR TITLE
Split out list and npz

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ And the linked list structure for `.npz` files:
 ## API
 The API is really simple. There is only ten public functions:
 
+    /* These are the four functions for loading and saving .npy files */
     npy_array_t*      npy_array_load        ( const char *filename);
     void              npy_array_dump        ( const npy_array_t *m );
     void              npy_array_save        ( const char *filename, const npy_array_t *m );
     void              npy_array_free        ( npy_array_t *m );
     
+    /* These are the six functions for loading and saving .npz files and lists of numpy arrays */
     npy_array_list_t* npy_array_list_load   ( const char *filename );
     int               npy_array_list_save   ( const char *filename, npy_array_list_t *array_list );
     size_t            npy_array_list_length ( npy_array_list_t *array_list);
@@ -133,9 +135,7 @@ recommend to install this.
 This is written in a full hurry one afternoon, and then modified over some time.
 There isn't much of testing performed, and you can read the code to see what is does.
 All errors are written to STDERR. Consider this alpha. So, reading and writing of
-both `.npy` and `.npz` files seems to work OK -- some obvious bugs of course -- however
-there is still no support for `np.savez_compressed()` saved arrays, nor support for saving
-such files. (I guess I need to use MiniZip (from zlib) for that, and that creates a dependency.)
+both `.npy` and `.npz` files seems to work OK -- some obvious bugs of course -- 
 
 ## TODO
  * Bugfixes

--- a/example/README.md
+++ b/example/README.md
@@ -8,7 +8,7 @@ Generate some example numpy arrays and save them. This can be done by running th
 Now you can compile and run the example code.
 
     $ gcc -I.. -Wall -Wextra -O3 -c example.c
-    $ gcc -o example example.o -L.. -lnpy_array
+    $ gcc -o example example.o -L.. -lnpy_array -lzip
 
 Now run the example with a file as command line argument.
 

--- a/example/example.c
+++ b/example/example.c
@@ -1,4 +1,5 @@
 #include "npy_array.h"
+#include "npy_array_list.h"
 #include <stdio.h>
 int main(int argc, char *argv[])
 {

--- a/npy_array.c
+++ b/npy_array.c
@@ -4,7 +4,6 @@
 #include <string.h>
 #include <ctype.h>
 #include <assert.h>
-#include <stdarg.h>
 
 #define NPY_ARRAY_MAGIC_STRING {0x93,'N','U','M','P','Y'}
 #define NPY_ARRAY_MAGIC_LENGTH 6
@@ -20,18 +19,12 @@
 #define NPY_ARRAY_SHAPE_BUFSIZE 512
 #define NPY_ARRAY_DICT_BUFSIZE 1024
 
-#define MAX_FILENAME_LEN 80
-
 typedef int64_t (*reader_func)( void *fp, void *buffer, uint64_t nbytes );
 static int64_t read_file( void *fp, void *buffer, uint64_t nbytes )
 {
     return (int64_t) fread( buffer, 1, nbytes, (FILE *) fp );
 }
 
-static int64_t read_zip( void *fp, void *buffer, uint64_t nbytes )
-{
-    return (int64_t) zip_fread( (zip_file_t *) fp, buffer, nbytes );
-}
 
 static void _header_from_npy_array( const npy_array_t *m,  char *buf, size_t *hlen )
 {
@@ -94,159 +87,6 @@ static size_t _calculate_datasize( const npy_array_t *m )
     return n_elements * m->elem_size;
 }
 
-static npy_array_list_t * npy_array_list_new()
-{
-    npy_array_list_t *list = malloc( sizeof(npy_array_list_t ));
-    if( !list )
-        return NULL; /* Whoops. */
-
-    list->array    = NULL;
-    list->filename = NULL;
-    list->next     = NULL;
-    return list;
-}
-
-void npy_array_list_free( npy_array_list_t *list )
-{
-    if( !list )
-        return;
-    if( list->array )
-        npy_array_free( list->array );
-    if( list->filename )
-        free( list->filename );
-    if( list->next )
-        npy_array_list_free( list->next );
-    free( list );
-}
-
-static char * _va_args_filename( const char *filename, va_list ap1 )
-{
-    va_list ap2;
-    int len;
-     
-    va_copy( ap2, ap1); 
-    len = vsnprintf( NULL, 0, filename, ap1 );
-    va_end( ap1 );
-
-    if( len > MAX_FILENAME_LEN ){
-        /* If someone is trying to cook up a special filename that can contain executable code, I think it is wise
-           to limit the length of the filename */
-        fprintf( stderr, "Warning: Cannot save numpy array. Your filename is too long."
-                " Please limit the filename to %d characters.\n", MAX_FILENAME_LEN );
-        return NULL;
-    }
-
-    char *real_filename = malloc( (len+1) * sizeof(char));
-    assert( real_filename );
-
-    vsprintf( real_filename, filename, ap2 );
-    va_end( ap2 );
-
-    return real_filename;
-}
-
-static npy_array_list_t * _list_append( npy_array_list_t *list, npy_array_list_t *new_elem )
-{
-    if(list) {
-        npy_array_list_t *last = list;
-        while(last->next)
-            last = last->next;
-        last->next = new_elem;
-        return list;
-    }
-    new_elem->next = NULL;
-    return new_elem;
-}
-
-static npy_array_list_t * _list_prepend( npy_array_list_t *list, npy_array_list_t *new_elem )
-{
-    new_elem->next = list;
-    return new_elem;
-}
-
-#define create_extend_list_func(oper) \
-npy_array_list_t * npy_array_list_ ##oper ( npy_array_list_t *list, npy_array_t *array, const char *filename, ... ) \
-{ \
-    npy_array_list_t *new_list = npy_array_list_new(); \
-    if ( !new_list ) return list; \
-    new_list->array = array; \
-\
-    va_list ap1; \
-    va_start( ap1, filename ); \
-    new_list->filename = _va_args_filename( filename, ap1 ); \
-    assert( new_list->filename ); \
-    va_end( ap1 ); \
-\
-    return _list_ ##oper ( list, new_list ); \
-} 
-/* Expand the macros */
-create_extend_list_func(append)
-create_extend_list_func(prepend)
-#undef create_extend_list_func
-
-static char * _new_internal_filename( int n )
-{
-    char *filename = malloc( MAX_FILENAME_LEN * sizeof(char) );
-    if( filename )
-        sprintf( filename, "arr_%d.npy", n );
-    return filename;
-}
-
-int npy_array_list_save( const char *filename, npy_array_list_t *array_list )
-{
-    return npy_array_list_save_compressed( filename, array_list, ZIP_CM_STORE, 0);
-}
-
-int npy_array_list_save_compressed( const char *filename, npy_array_list_t *array_list, zip_int32_t comp, zip_uint32_t comp_flags)
-{
-    if ( !array_list )
-        return 0;
-
-    /* FIXME: Better test */
-    zip_t *zip = zip_open( filename, ZIP_CREATE | ZIP_TRUNCATE, NULL );
-    assert( zip );
-
-    int n = 0;
-    for( npy_array_list_t *iter = array_list; iter; iter = iter->next ){
-        if ( zip_set_file_compression(zip, n, comp, comp_flags) < 0){
-            /* what is wrong? */
-        }
-        /* if the filename is not set, set one. However.. if the list was created with append and prepend,
-         * this will never be true. */
-        if(!iter->filename)
-            iter->filename = _new_internal_filename( n );
-
-        char header[NPY_ARRAY_DICT_BUFSIZE + NPY_ARRAY_PREHEADER_LENGTH] = {'\0'};
-
-        npy_array_t *m = iter->array;
-
-        size_t hlen = 0;
-        _header_from_npy_array( m, header, &hlen );
-        size_t datasize = _calculate_datasize( m );
-
-        char *matrix_npy_format = malloc( hlen + datasize );
-        assert( matrix_npy_format );
-        memcpy( matrix_npy_format, header, hlen );
-        memcpy( matrix_npy_format + hlen, m->data, datasize );
-
-        /* FIXME: Check for error */
-        zip_source_t *s = zip_source_buffer_create( matrix_npy_format, hlen + datasize, 1, NULL);
-        assert(s); 
-
-        int idx = zip_file_add( zip, iter->filename, s, ZIP_FL_ENC_UTF_8 );
-        if( idx != n )
-            fprintf( stderr, "Warning: Index and counter mismatch.");
-
-        // fprintf(stderr, "Error: %s\n", zip_strerror( zip ));
-        
-        n++;
-    }
-    if ( zip_close( zip ) < 0 ){
-        fprintf(stderr, "What? no close?\n");
-        fprintf(stderr, "Error: %s\n", zip_strerror( zip ));
-    }
-    return n;
-}
 
 static char *find_header_item( const char *item, const char *header)
 {
@@ -260,7 +100,7 @@ static inline char endianness(){
 }
 
 /* consider if this function should be exported to the end user */
-static npy_array_t * _read_matrix( void *fp, reader_func read_func )
+npy_array_t * _read_matrix( void *fp, reader_func read_func )
 {
     char fixed_header[NPY_ARRAY_PREHEADER_LENGTH + 1];
     size_t chk = read_func( fp, fixed_header, NPY_ARRAY_PREHEADER_LENGTH );
@@ -345,7 +185,6 @@ static npy_array_t * _read_matrix( void *fp, reader_func read_func )
     else
         fprintf(stderr, "Warning: No matrix order found, assuming fortran_order=False");
 
-
     /* FIXME: This only works if there is one and only one leading spaces. */
     char *shape   = find_header_item("'shape': ", header);
     assert(shape);
@@ -399,50 +238,6 @@ npy_array_t * npy_array_load( const char *filename )
 
     fclose(fp);
     return m;
-}
-
-npy_array_list_t * npy_array_list_load( const char *filename )
-{
-    /* FIXME: better check. what went wrong? */
-    zip_t *zip = zip_open(filename, ZIP_RDONLY, NULL );
-    if( !zip ){
-        fprintf(stderr, "cannot zip_open file: %s\n", filename );
-        return NULL;
-    }
-
-    npy_array_list_t *list = NULL;
-    for( int i = 0; i < zip_get_num_entries( zip, 0 ); i++ ){
-        zip_file_t *fp = zip_fopen_index( zip, i, 0 ); /* FIXME Better checks */
-        if (!fp ){
-            fprintf(stderr, "Warning: Cannot open internal file of index %d in archive '%s'.\n", i, filename );
-            continue;
-        }
-        npy_array_t *arr = _read_matrix( fp, &read_zip );
-        zip_fclose( fp );
-        if(!arr) {
-            fprintf(stderr, "Warning: Cannot read matrix.\n");
-            continue;
-        }
-        list = npy_array_list_append( list, arr, zip_get_name( zip, i, 0 ));
-    }
-
-    zip_close(zip);
-    
-    return list;
-}
-
-size_t npy_array_list_length( npy_array_list_t *arr)
-{
-    if (!arr) return 0;
-
-    size_t len = 0;
-    npy_array_list_t *iter = arr;
-
-    while( iter ){
-        len++;
-        iter = iter->next;
-    }
-    return len;
 }
 
 void npy_array_dump( const npy_array_t *m )

--- a/npy_array.h
+++ b/npy_array.h
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <zip.h>
 
 #define NPY_ARRAY_MAX_DIMENSIONS 8
 
@@ -18,24 +17,12 @@ typedef struct _npy_array_t {
     bool              fortran_order;
 } npy_array_t;
 
-typedef struct _npy_array_list_t {
-    npy_array_t      *array;
-    char             *filename;
-    struct _npy_array_list_t *next;
-} npy_array_list_t;
+typedef int64_t (*reader_func)( void *fp, void *buffer, uint64_t nbytes );
 
-npy_array_t*      npy_array_load       ( const char *filename);
+npy_array_t*      npy_array_load       ( const char *filename );
 void              npy_array_dump       ( const npy_array_t *m );
 void              npy_array_save       ( const char *filename, const npy_array_t *m );
 void              npy_array_free       ( npy_array_t *m );
 
-npy_array_list_t* npy_array_list_load           ( const char *filename );
-int               npy_array_list_save           ( const char *filename, npy_array_list_t *array_list );
-int               npy_array_list_save_compressed( const char *filename, npy_array_list_t *array_list, zip_int32_t comp, zip_uint32_t comp_flags);
-size_t            npy_array_list_length         ( npy_array_list_t *array_list);
-void              npy_array_list_free           ( npy_array_list_t *array_list);
-
-npy_array_list_t* npy_array_list_prepend( npy_array_list_t *list, npy_array_t *array, const char *filename, ...);
-npy_array_list_t* npy_array_list_append ( npy_array_list_t *list, npy_array_t *array, const char *filename, ...);
-
+npy_array_t *     _read_matrix         ( void *fp, reader_func read_func );
 #endif  /* __NPY_ARRAY_H__ */

--- a/npy_array.h
+++ b/npy_array.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #define NPY_ARRAY_MAX_DIMENSIONS 8
 
@@ -17,12 +18,24 @@ typedef struct _npy_array_t {
     bool              fortran_order;
 } npy_array_t;
 
-typedef int64_t (*reader_func)( void *fp, void *buffer, uint64_t nbytes );
 
 npy_array_t*      npy_array_load       ( const char *filename );
 void              npy_array_dump       ( const npy_array_t *m );
 void              npy_array_save       ( const char *filename, const npy_array_t *m );
 void              npy_array_free       ( npy_array_t *m );
 
-npy_array_t *     _read_matrix         ( void *fp, reader_func read_func );
+/* Convenient functions - I'll make them public for now, but use these with care
+   as I might remove these from the exported list of public functions. */
+size_t            npy_array_calculate_datasize ( const npy_array_t *m );
+size_t            npy_array_get_header         ( const npy_array_t *m,  char *buf );
+
+static inline int64_t read_file( void *fp, void *buffer, uint64_t nbytes )
+{
+    return (int64_t) fread( buffer, 1, nbytes, (FILE *) fp );
+}
+
+/* _read_matrix() might be public in the future as a macro or something.
+   Don't use it now as I will change name of it in case I make it public. */
+typedef int64_t (*reader_func)( void *fp, void *buffer, uint64_t nbytes );
+npy_array_t *     _read_matrix( void *fp, reader_func read_func );
 #endif  /* __NPY_ARRAY_H__ */

--- a/npy_array_list.c
+++ b/npy_array_list.c
@@ -1,0 +1,212 @@
+#include "npy_array_list.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+#include <stdarg.h>
+
+#define MAX_FILENAME_LEN 80
+static int64_t read_zip( void *fp, void *buffer, uint64_t nbytes )
+{
+    return (int64_t) zip_fread( (zip_file_t *) fp, buffer, nbytes );
+}
+
+static npy_array_list_t * npy_array_list_new()
+{
+    npy_array_list_t *list = malloc( sizeof(npy_array_list_t ));
+    if( !list )
+        return NULL; /* Whoops. */
+
+    list->array    = NULL;
+    list->filename = NULL;
+    list->next     = NULL;
+    return list;
+}
+
+void npy_array_list_free( npy_array_list_t *list )
+{
+    if( !list )
+        return;
+    if( list->array )
+        npy_array_free( list->array );
+    if( list->filename )
+        free( list->filename );
+    if( list->next )
+        npy_array_list_free( list->next );
+    free( list );
+}
+
+static char * _va_args_filename( const char *filename, va_list ap1 )
+{
+    va_list ap2;
+    int len;
+     
+    va_copy( ap2, ap1); 
+    len = vsnprintf( NULL, 0, filename, ap1 );
+    va_end( ap1 );
+
+    if( len > MAX_FILENAME_LEN ){
+        /* If someone is trying to cook up a special filename that can contain executable code, I think it is wise
+           to limit the length of the filename */
+        fprintf( stderr, "Warning: Cannot save numpy array. Your filename is too long."
+                " Please limit the filename to %d characters.\n", MAX_FILENAME_LEN );
+        return NULL;
+    }
+
+    char *real_filename = malloc( (len+1) * sizeof(char));
+    assert( real_filename );
+
+    vsprintf( real_filename, filename, ap2 );
+    va_end( ap2 );
+
+    return real_filename;
+}
+
+static npy_array_list_t * _list_append( npy_array_list_t *list, npy_array_list_t *new_elem )
+{
+    if(list) {
+        npy_array_list_t *last = list;
+        while(last->next)
+            last = last->next;
+        last->next = new_elem;
+        return list;
+    }
+    new_elem->next = NULL;
+    return new_elem;
+}
+
+static npy_array_list_t * _list_prepend( npy_array_list_t *list, npy_array_list_t *new_elem )
+{
+    new_elem->next = list;
+    return new_elem;
+}
+
+#define create_extend_list_func(oper) \
+npy_array_list_t * npy_array_list_ ##oper ( npy_array_list_t *list, npy_array_t *array, const char *filename, ... ) \
+{ \
+    npy_array_list_t *new_list = npy_array_list_new(); \
+    if ( !new_list ) return list; \
+    new_list->array = array; \
+\
+    va_list ap1; \
+    va_start( ap1, filename ); \
+    new_list->filename = _va_args_filename( filename, ap1 ); \
+    assert( new_list->filename ); \
+    va_end( ap1 ); \
+\
+    return _list_ ##oper ( list, new_list ); \
+} 
+/* Expand the macros */
+create_extend_list_func(append)
+create_extend_list_func(prepend)
+#undef create_extend_list_func
+
+static char * _new_internal_filename( int n )
+{
+    char *filename = malloc( MAX_FILENAME_LEN * sizeof(char) );
+    if( filename )
+        sprintf( filename, "arr_%d.npy", n );
+    return filename;
+}
+
+int npy_array_list_save( const char *filename, npy_array_list_t *array_list )
+{
+    return npy_array_list_save_compressed( filename, array_list, ZIP_CM_STORE, 0);
+}
+
+int npy_array_list_save_compressed( const char *filename, npy_array_list_t *array_list, zip_int32_t comp, zip_uint32_t comp_flags)
+{
+    if ( !array_list )
+        return 0;
+
+    /* FIXME: Better test */
+    zip_t *zip = zip_open( filename, ZIP_CREATE | ZIP_TRUNCATE, NULL );
+    assert( zip );
+
+    int n = 0;
+    for( npy_array_list_t *iter = array_list; iter; iter = iter->next ){
+        if ( zip_set_file_compression(zip, n, comp, comp_flags) < 0){
+            /* what is wrong? */
+        }
+        /* if the filename is not set, set one. However.. if the list was created with append and prepend,
+         * this will never be true. */
+        if(!iter->filename)
+            iter->filename = _new_internal_filename( n );
+
+        char header[NPY_ARRAY_DICT_BUFSIZE + NPY_ARRAY_PREHEADER_LENGTH] = {'\0'};
+
+        npy_array_t *m = iter->array;
+
+        size_t hlen = 0;
+        _header_from_npy_array( m, header, &hlen );
+        size_t datasize = _calculate_datasize( m );
+
+        char *matrix_npy_format = malloc( hlen + datasize );
+        assert( matrix_npy_format );
+        memcpy( matrix_npy_format, header, hlen );
+        memcpy( matrix_npy_format + hlen, m->data, datasize );
+
+        /* FIXME: Check for error */
+        zip_source_t *s = zip_source_buffer_create( matrix_npy_format, hlen + datasize, 1, NULL);
+        assert(s); 
+
+        int idx = zip_file_add( zip, iter->filename, s, ZIP_FL_ENC_UTF_8 );
+        if( idx != n )
+            fprintf( stderr, "Warning: Index and counter mismatch.");
+
+        // fprintf(stderr, "Error: %s\n", zip_strerror( zip ));
+        
+        n++;
+    }
+    if ( zip_close( zip ) < 0 ){
+        fprintf(stderr, "What? no close?\n");
+        fprintf(stderr, "Error: %s\n", zip_strerror( zip ));
+    }
+    return n;
+}
+
+npy_array_list_t * npy_array_list_load( const char *filename )
+{
+    /* FIXME: better check. what went wrong? */
+    zip_t *zip = zip_open(filename, ZIP_RDONLY, NULL );
+    if( !zip ){
+        fprintf(stderr, "cannot zip_open file: %s\n", filename );
+        return NULL;
+    }
+
+    npy_array_list_t *list = NULL;
+    for( int i = 0; i < zip_get_num_entries( zip, 0 ); i++ ){
+        zip_file_t *fp = zip_fopen_index( zip, i, 0 ); /* FIXME Better checks */
+        if (!fp ){
+            fprintf(stderr, "Warning: Cannot open internal file of index %d in archive '%s'.\n", i, filename );
+            continue;
+        }
+        npy_array_t *arr = _read_matrix( fp, &read_zip );
+        zip_fclose( fp );
+        if(!arr) {
+            fprintf(stderr, "Warning: Cannot read matrix.\n");
+            continue;
+        }
+        list = npy_array_list_append( list, arr, zip_get_name( zip, i, 0 ));
+    }
+
+    zip_close(zip);
+    
+    return list;
+}
+
+size_t npy_array_list_length( npy_array_list_t *arr)
+{
+    if (!arr) return 0;
+
+    size_t len = 0;
+    npy_array_list_t *iter = arr;
+
+    while( iter ){
+        len++;
+        iter = iter->next;
+    }
+    return len;
+}
+

--- a/npy_array_list.h
+++ b/npy_array_list.h
@@ -20,4 +20,9 @@ void              npy_array_list_free           ( npy_array_list_t *array_list);
 npy_array_list_t* npy_array_list_prepend( npy_array_list_t *list, npy_array_t *array, const char *filename, ...);
 npy_array_list_t* npy_array_list_append ( npy_array_list_t *list, npy_array_t *array, const char *filename, ...);
 
+static inline int64_t read_zip( void *fp, void *buffer, uint64_t nbytes )
+{
+    return (int64_t) zip_fread( (zip_file_t *) fp, buffer, nbytes );
+}
+
 #endif /*  __NPY_ARRAY_LIST_H__  */

--- a/npy_array_list.h
+++ b/npy_array_list.h
@@ -1,0 +1,23 @@
+#ifndef __NPY_ARRAY_LIST_H__
+#define __NPY_ARRAY_LIST_H__
+
+#include "npy_array.h"
+#include <zip.h>
+
+typedef struct _npy_array_list_t {
+    npy_array_t      *array;
+    char             *filename;
+    struct _npy_array_list_t *next;
+} npy_array_list_t;
+
+npy_array_list_t* npy_array_list_load           ( const char *filename );
+int               npy_array_list_save           ( const char *filename, npy_array_list_t *array_list );
+int               npy_array_list_save_compressed( const char *filename, npy_array_list_t *array_list,
+                                                  zip_int32_t comp, zip_uint32_t comp_flags);
+size_t            npy_array_list_length         ( npy_array_list_t *array_list);
+void              npy_array_list_free           ( npy_array_list_t *array_list);
+
+npy_array_list_t* npy_array_list_prepend( npy_array_list_t *list, npy_array_t *array, const char *filename, ...);
+npy_array_list_t* npy_array_list_append ( npy_array_list_t *list, npy_array_t *array, const char *filename, ...);
+
+#endif /*  __NPY_ARRAY_LIST_H__  */


### PR DESCRIPTION
This commit splits the code into two translation unit. One, `npy_array.[ch]` for plain load and save of one single numpy array to a `.npy` file, and another translation unit called `npy_array_list.[ch]` for handling multiple numpy arrays and `.npz` files. This PR does not address any listed issues.