### PR TITLE
Create pkg-config-path is not exist - typical when building package

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -66,7 +66,7 @@ install: $(target) $(header_files) $(pkg_conf_pc)
 	@echo 'Copying $(target)'
 	@strip $(strip_flags) $(DESTDIR)$(PREFIX)/lib/$(target)
 	@for h in $(header_files); do cp $$h $(DESTDIR)$(PREFIX)/include/ ; echo "Copying $$h"; done
-	@if [ -e $(pkg_conf_pc) ]; then cp $(pkg_conf_pc) $(pkg_config_path); fi
+	@if [ -e $(pkg_conf_pc) ]; then mkdir -p $(DESTDIR)$(pkg_config_path); cp $(pkg_conf_pc) $(DESTDIR)$(pkg_config_path); fi
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
Copying npy_array.pc into the pkg-config-path requires that the path is created. 
This PR creates the path before copying the file.
"Of course the directory is already there" I hear you say. No, it is not there when you are building a package, say an rpm or pacman packet or a .deb or whatever you build.