### PR TITLE
Shallow copy of npy_array_t

### DIFF
--- a/.github/workflows/make_and_exmples.yml
+++ b/.github/workflows/make_and_exmples.yml
@@ -33,7 +33,9 @@ jobs:
          ./how_to_save_npz
          ./how_to_load my_4_by_3_array_shortcut.npy
          ./how_to_load_npz iarray_and_darray.npz
-    - name: Test install 
+         ./copying
+         ./copying_read
+    - name: Test install
       run: |
          sudo make install
          unset LD_LIBRARY_PATH

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *~
 *.npy
 *.npz
+Makefile
+*.so
+*.pc
+*.d

--- a/README.md
+++ b/README.md
@@ -119,11 +119,12 @@ And the linked list structure for `.npz` files:
     } npy_array_list_t;
 
 ## API
-The API is really simple. There is only ~~ten~~eleven public functions:
+The API is really simple. There is only ~~eleven~~twelve public functions:
 
     /* These are the four functions for loading and saving .npy files */
     npy_array_t*      npy_array_load        ( const char *filename);
     npy_array_t*      npy_array_mmap        ( const char *filename);
+    npy_array_t*      npy_array_alloc       ( const npy_array_t *m );
     void              npy_array_dump        ( const npy_array_t *m );
     void              npy_array_save        ( const char *filename, const npy_array_t *m );
     void              npy_array_free        ( npy_array_t *m );
@@ -154,6 +155,27 @@ You can then run example with a _NumPy_ file as argument.
         npy_array_save( "tester_save.npy", m);
         npy_array_free( m );
         return 0;
+    }
+
+## Saving lists of numpy arrays (and building them)
+Here is an example of saving multiple arrays into a single .npz file. You can
+compile this with:
+
+    gcc -O3 -Wall -Wextra -pedantic -std=c11 -c example_list.c
+    gcc -o example_list example_list.o npy_array.o npy_array_list.o -lzip
+
+You can the run example_list with a filename (_NumPy_ compressed) as argument.
+
+    #include "npy_array_list.h"
+    int main(int argc, char *argv[])
+    {
+        if( argc != 2 ) return -1;
+        double data[] = {0,1,2,3,4,5};
+        npy_array_list_t* list = NULL;
+        list = npy_array_list_append( list, NPY_ARRAY_ALLOCATOR(data, SHAPE(3,2), NPY_DTYPE_FLOAT64), "matrix" );
+        list = npy_array_list_append( list, NPY_ARRAY_ALLOCATOR(data, SHAPE(2,1,2), NPY_DTYPE_FLOAT64), "tensor" );
+        npy_array_list_save_compressed( argv[1], list, ZIP_CM_DEFAULT, 0 );
+        npy_array_list_free( list );
     }
 
 ## Saving other arraylike data as _NumPy_ format.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ The API is really simple. There is only ~~eleven~~twelve public functions:
     /* These are the four functions for loading and saving .npy files */
     npy_array_t*      npy_array_load        ( const char *filename);
     npy_array_t*      npy_array_mmap        ( const char *filename);
-    npy_array_t*      npy_array_alloc       ( const npy_array_t *m );
+    npy_array_t*      npy_array_deepcopy    ( const npy_array_t *m );
+    npy_array_t*      npy_array_copy        ( const npy_array_t *m );
     void              npy_array_dump        ( const npy_array_t *m );
     void              npy_array_save        ( const char *filename, const npy_array_t *m );
     void              npy_array_free        ( npy_array_t *m );
@@ -167,13 +168,22 @@ compile this with:
 You can the run example_list with a filename (_NumPy_ compressed) as argument.
 
     #include "npy_array_list.h"
+
     int main(int argc, char *argv[])
     {
         if( argc != 2 ) return -1;
+
         double data[] = {0,1,2,3,4,5};
+
         npy_array_list_t* list = NULL;
-        list = npy_array_list_append( list, NPY_ARRAY_ALLOCATOR(data, SHAPE(3,2), NPY_DTYPE_FLOAT64), "matrix" );
-        list = npy_array_list_append( list, NPY_ARRAY_ALLOCATOR(data, SHAPE(2,1,2), NPY_DTYPE_FLOAT64), "tensor" );
+
+        // the first npy_array_t* holds a reference to the data array
+        list = npy_array_list_append( list,
+            NPY_ARRAY_BUILDER_COPY(data, SHAPE(3,2), NPY_DTYPE_FLOAT64), "matrix" );
+        // the second npy_array_t* holds a copy of the data array (hence DEEPCOPY)
+        list = npy_array_list_append( list,
+            NPY_ARRAY_BUILDER_DEEPCOPY(data, SHAPE(2,1,2), NPY_DTYPE_FLOAT64), "tensor" );
+
         npy_array_list_save_compressed( argv[1], list, ZIP_CM_DEFAULT, 0 );
         npy_array_list_free( list );
     }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ And the linked list structure for `.npz` files:
     } npy_array_list_t;
 
 ## API
-The API is really simple. There is only ~~eleven~~twelve public functions:
+The API is really simple. There is only 13 public functions:
 
     /* These are the four functions for loading and saving .npy files */
     npy_array_t*      npy_array_load        ( const char *filename);

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,9 +1,9 @@
-CC = gcc
-CFLAGS = -std=c99 -Wall -Wextra -O3 -I.. 
-LDLIBS = -L.. -lnpy_array
+CC ?= gcc
+CFLAGS += -std=c99 -Wall -Wextra -O3 -I..
+LDLIBS += -L.. -lnpy_array
 
 SOURCES = $(wildcard *.c)
-PROGRAMS = $(patsubst %.c,%,$(SOURCES)) 
+PROGRAMS = $(patsubst %.c,%,$(SOURCES))
 
 all: $(PROGRAMS)
 

--- a/example/copying.c
+++ b/example/copying.c
@@ -2,19 +2,23 @@
 
 int main(int argc, char *argv[])
 {
-    if( argc != 2 ) return -1;
+    const char* fname = (argc != 2) ? "copy.npz" : argv[1];
 
-    double data[] = {0,1,2,3,4,5};
+    const double data[] = {0,1,2, 3,4,5};
+    const int32_t idata[] = {0,1, 2,3,
+                             4,5, 6,7,
+                             8,9, 10,11};
+    const char names[][8] = { "double", "int" };
 
     npy_array_list_t* list = NULL;
 
     // the first npy_array_t* holds a reference to the data array
     list = npy_array_list_append( list,
-        NPY_ARRAY_BUILDER_COPY(data, SHAPE(3,2), NPY_DTYPE_FLOAT64), "matrix" );
+        NPY_ARRAY_BUILDER_COPY(data, SHAPE(2,3), NPY_DTYPE_FLOAT64), names[0] );
     // the second npy_array_t* holds a copy of the data array (hence DEEPCOPY)
     list = npy_array_list_append( list,
-        NPY_ARRAY_BUILDER_DEEPCOPY(data, SHAPE(2,1,2), NPY_DTYPE_FLOAT64), "tensor" );
+        NPY_ARRAY_BUILDER_DEEPCOPY(idata, SHAPE(3,2,2), NPY_DTYPE_INT32), names[1] );
 
-    npy_array_list_save_compressed( argv[1], list, ZIP_CM_DEFAULT, 0 );
+    npy_array_list_save_compressed( fname, list, ZIP_CM_DEFAULT, 0 );
     npy_array_list_free( list );
 }

--- a/example/copying.c
+++ b/example/copying.c
@@ -1,5 +1,6 @@
 #include "npy_array_list.h"
 
+// the first block must be the same as in copying_read.c
 int main(int argc, char *argv[])
 {
     const char* fname = (argc != 2) ? "copy.npz" : argv[1];

--- a/example/copying.c
+++ b/example/copying.c
@@ -1,0 +1,20 @@
+#include "npy_array_list.h"
+
+int main(int argc, char *argv[])
+{
+    if( argc != 2 ) return -1;
+
+    double data[] = {0,1,2,3,4,5};
+
+    npy_array_list_t* list = NULL;
+
+    // the first npy_array_t* holds a reference to the data array
+    list = npy_array_list_append( list,
+        NPY_ARRAY_BUILDER_COPY(data, SHAPE(3,2), NPY_DTYPE_FLOAT64), "matrix" );
+    // the second npy_array_t* holds a copy of the data array (hence DEEPCOPY)
+    list = npy_array_list_append( list,
+        NPY_ARRAY_BUILDER_DEEPCOPY(data, SHAPE(2,1,2), NPY_DTYPE_FLOAT64), "tensor" );
+
+    npy_array_list_save_compressed( argv[1], list, ZIP_CM_DEFAULT, 0 );
+    npy_array_list_free( list );
+}

--- a/example/copying_read.c
+++ b/example/copying_read.c
@@ -1,0 +1,58 @@
+#include "npy_array_list.h"
+
+#include <string.h>
+#define MIN(x,y) ((x)<(y)?(x):(y))
+
+// the first block must be the same as in copying.c
+int main(int argc, char *argv[])
+{
+    const char* fname = (argc != 2) ? "copy.npz" : argv[1];
+
+    const double data[] = {0,1,2, 3,4,5};
+    const int32_t idata[] = {0,1, 2,3,
+                             4,5, 6,7,
+                             8,9, 10,11};
+    const char names[][8] = { "double", "int" };
+
+    // we load the file and check whether it contains the same data
+    npy_array_list_t *list = npy_array_list_load( fname );
+
+    int errors = 0;
+    int visited_data = 0,
+        visited_idata = 0;
+    npy_array_list_t *elem = list;
+    while (elem != NULL) {
+        npy_array_t* ary = elem->array;
+        size_t ary_sz = npy_array_calculate_datasize( ary );
+
+        char* cmp = NULL;
+        size_t cmp_sz = 0;
+
+        if (!strcmp( elem->filename, names[0] )) {
+            cmp = (char*)data;
+            cmp_sz = sizeof(data);
+            visited_data++;
+        } else if (!strcmp( elem->filename, names[1] )) {
+            cmp = (char*)idata;
+            cmp_sz = sizeof(idata);
+            visited_idata++;
+        }
+
+        errors += (cmp_sz != ary_sz);
+        if (cmp != NULL) {
+            errors += (memcmp( ary->data, cmp, MIN(cmp_sz,ary_sz) ) != 0);
+        } else {
+            errors++;
+        }
+
+        elem = elem->next;
+    }
+
+    errors += (visited_data != 1);
+    errors += (visited_idata != 1);
+
+    npy_array_list_free( list );
+
+    // we return the number of errors/inconsistencies
+    return errors;
+}

--- a/npy_array.c
+++ b/npy_array.c
@@ -399,13 +399,22 @@ void npy_array_free( npy_array_t *m )
 }
 
 #define MIN( x, y ) ((x) < (y) ? (x) : (y))
-npy_array_t* npy_array_alloc( const npy_array_t* m ) {
+npy_array_t* npy_array_deepcopy( const npy_array_t* m ) {
     npy_array_t* ary = calloc( 1, sizeof(*ary) );
+    if (!ary) {
+        fprintf(stderr, "Cannot allocate data structure!\n");
+        return NULL;
+    }
     ary->ndim = MIN( m->ndim, NPY_ARRAY_MAX_DIMENSIONS );
     memcpy( ary->shape, m->shape, sizeof(ary->shape) );
     ary->typechar = m->typechar;
     ary->elem_size = m->elem_size;
     ary->data = malloc( npy_array_calculate_datasize(ary) );
+    if (!ary->data) {
+        fprintf(stderr, "Cannot allocate memory!\n");
+        free(ary);
+        return NULL;
+    }
     memcpy( ary->data, m->data, npy_array_calculate_datasize(ary) );
     return ary;
 }

--- a/npy_array.c
+++ b/npy_array.c
@@ -45,7 +45,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ctype.h>
 #include <assert.h>
 
-#define NPY_ARRAY_MAGIC_STRING {0x93,'N','U','M','P','Y'}
+#define NPY_ARRAY_MAGIC_STRING {-109,'N','U','M','P','Y'}
 #define NPY_ARRAY_MAJOR_VERSION_IDX 6
 #define NPY_ARRAY_MINOR_VERSION_IDX 7
 
@@ -396,4 +396,16 @@ void npy_array_free( npy_array_t *m )
         free( m->data );
 
     free( m );
+}
+
+#define MIN( x, y ) ((x) < (y) ? (x) : (y))
+npy_array_t* npy_array_alloc( const npy_array_t* m ) {
+    npy_array_t* ary = calloc( 1, sizeof(*ary) );
+    ary->ndim = MIN( m->ndim, NPY_ARRAY_MAX_DIMENSIONS );
+    memcpy( ary->shape, m->shape, sizeof(ary->shape) );
+    ary->typechar = m->typechar;
+    ary->elem_size = m->elem_size;
+    ary->data = malloc( npy_array_calculate_datasize(ary) );
+    memcpy( ary->data, m->data, npy_array_calculate_datasize(ary) );
+    return ary;
 }

--- a/npy_array.h
+++ b/npy_array.h
@@ -60,7 +60,7 @@ typedef struct _npy_array_t {
 
 npy_array_t*      npy_array_load       ( const char *filename );
 npy_array_t*      npy_array_mmap       ( const char *filename );
-npy_array_t*      npy_array_alloc      ( const npy_array_t *m );
+npy_array_t*      npy_array_deepcopy   ( const npy_array_t *m );
 void              npy_array_dump       ( const npy_array_t *m );
 void              npy_array_save       ( const char *filename, const npy_array_t *m );
 void              npy_array_free       ( npy_array_t *m );
@@ -88,7 +88,7 @@ npy_array_t *     _read_matrix( void *fp, reader_func read_func );
 #define NPY_ARRAY_BUILDER(_data,_shape,...) \
     &(npy_array_t){ .data=(char*)_data, _shape, __VA_ARGS__ } 
 #define NPY_ARRAY_ALLOCATOR(...) \
-    npy_array_alloc(NPY_ARRAY_BUILDER(__VA_ARGS__))
+    npy_array_deepcopy(NPY_ARRAY_BUILDER(__VA_ARGS__))
 
 #define NPY_DTYPE_FLOAT16    .typechar='f', .elem_size=2
 #define NPY_DTYPE_FLOAT32    .typechar='f', .elem_size=4

--- a/npy_array.h
+++ b/npy_array.h
@@ -60,6 +60,7 @@ typedef struct _npy_array_t {
 
 npy_array_t*      npy_array_load       ( const char *filename );
 npy_array_t*      npy_array_mmap       ( const char *filename );
+npy_array_t*      npy_array_alloc      ( const npy_array_t *m );
 void              npy_array_dump       ( const npy_array_t *m );
 void              npy_array_save       ( const char *filename, const npy_array_t *m );
 void              npy_array_free       ( npy_array_t *m );
@@ -86,6 +87,8 @@ npy_array_t *     _read_matrix( void *fp, reader_func read_func );
 #define SHAPE(...) .shape = {__VA_ARGS__}, .ndim = _NARG(__VA_ARGS__)
 #define NPY_ARRAY_BUILDER(_data,_shape,...) \
     &(npy_array_t){ .data=(char*)_data, _shape, __VA_ARGS__ } 
+#define NPY_ARRAY_ALLOCATOR(...) \
+    npy_array_alloc(NPY_ARRAY_BUILDER(__VA_ARGS__))
 
 #define NPY_DTYPE_FLOAT16    .typechar='f', .elem_size=2
 #define NPY_DTYPE_FLOAT32    .typechar='f', .elem_size=4

--- a/npy_array.h
+++ b/npy_array.h
@@ -53,14 +53,16 @@ typedef struct _npy_array_t {
     char              typechar;
     size_t            elem_size;
     bool              fortran_order;
-    /* Consider map_addr as a private member. Do modify this pointer! Used for unmap() */
+    /* Consider map_addr and memory as a private members. Do not modify these pointers! */
     void             *map_addr;      /* pointer to the map if array is mmap()'ed -- else NULL */
+    char             *memory;        /* pointer to memory if array owns it -- else NULL */
 } npy_array_t;
 
 
 npy_array_t*      npy_array_load       ( const char *filename );
 npy_array_t*      npy_array_mmap       ( const char *filename );
 npy_array_t*      npy_array_deepcopy   ( const npy_array_t *m );
+npy_array_t*      npy_array_copy       ( const npy_array_t *m );
 void              npy_array_dump       ( const npy_array_t *m );
 void              npy_array_save       ( const char *filename, const npy_array_t *m );
 void              npy_array_free       ( npy_array_t *m );
@@ -87,7 +89,9 @@ npy_array_t *     _read_matrix( void *fp, reader_func read_func );
 #define SHAPE(...) .shape = {__VA_ARGS__}, .ndim = _NARG(__VA_ARGS__)
 #define NPY_ARRAY_BUILDER(_data,_shape,...) \
     &(npy_array_t){ .data=(char*)_data, _shape, __VA_ARGS__ } 
-#define NPY_ARRAY_ALLOCATOR(...) \
+#define NPY_ARRAY_BUILDER_COPY(...) \
+    npy_array_copy(NPY_ARRAY_BUILDER(__VA_ARGS__))
+#define NPY_ARRAY_BUILDER_DEEPCOPY(...) \
     npy_array_deepcopy(NPY_ARRAY_BUILDER(__VA_ARGS__))
 
 #define NPY_DTYPE_FLOAT16    .typechar='f', .elem_size=2


### PR DESCRIPTION
Following the discussion in #30, I implemented my suggestion of having a private data member that is NULL in case an npy_array_t* object doesn't own its data. If you think the interface is getting too cluttered by this I would be very happy to discuss other approaches.